### PR TITLE
Fix bugs and remove redundancy

### DIFF
--- a/src/domain/articles/mod.rs
+++ b/src/domain/articles/mod.rs
@@ -10,10 +10,9 @@ pub struct ArticleBody<T> {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ArticlesBody<T> {
     pub articles: Vec<T>,
-
-    #[serde(rename = "articlesCount")]
     pub articles_count: usize,
 }
 

--- a/src/domain/articles/request.rs
+++ b/src/domain/articles/request.rs
@@ -1,11 +1,11 @@
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ArticleCreateInput {
     pub title: String,
     pub description: String,
     pub body: String,
-    #[serde(rename = "tagList")]
     pub tag_list: Option<Vec<String>>,
 }
 

--- a/src/domain/articles/response.rs
+++ b/src/domain/articles/response.rs
@@ -6,22 +6,19 @@ use crate::{
 };
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Article {
     pub id: i32,
     pub slug: String,
     pub title: String,
     pub description: String,
     pub body: String,
-    #[serde(rename = "tagList")]
     pub tag_list: Vec<String>,
-    #[serde(rename = "createdAt")]
     pub created_at:
         ::prisma_client_rust::chrono::DateTime<::prisma_client_rust::chrono::FixedOffset>,
-    #[serde(rename = "updatedAt")]
     pub updated_at:
         ::prisma_client_rust::chrono::DateTime<::prisma_client_rust::chrono::FixedOffset>,
     pub favorited: bool,
-    #[serde(rename = "favoritesCount")]
     pub favorites_count: i32,
     pub author: Profile,
 }
@@ -48,16 +45,14 @@ impl article::Data {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Comment {
     pub id: i32,
     pub body: String,
-    #[serde(rename = "createdAt")]
     pub created_at:
         ::prisma_client_rust::chrono::DateTime<::prisma_client_rust::chrono::FixedOffset>,
-    #[serde(rename = "updatedAt")]
     pub updated_at:
         ::prisma_client_rust::chrono::DateTime<::prisma_client_rust::chrono::FixedOffset>,
-    #[serde(rename = "deletedAt")]
     pub deleted_at:
         Option<::prisma_client_rust::chrono::DateTime<::prisma_client_rust::chrono::FixedOffset>>,
     pub author: Profile,

--- a/src/domain/profiles/response.rs
+++ b/src/domain/profiles/response.rs
@@ -4,16 +4,9 @@ use crate::prisma::user;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Profile {
-    #[serde(rename = "username")]
     pub username: String,
-
-    #[serde(rename = "bio")]
     pub bio: Option<String>,
-
-    #[serde(rename = "image")]
     pub image: Option<String>,
-
-    #[serde(rename = "following")]
     pub following: bool,
 }
 

--- a/src/domain/users/response.rs
+++ b/src/domain/users/response.rs
@@ -3,21 +3,15 @@ use serde::{Deserialize, Serialize};
 use crate::prisma::user;
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct User {
-    #[serde(rename = "id")]
     pub id: i32,
-    #[serde(rename = "email")]
     pub email: String,
-    #[serde(rename = "username")]
     pub username: String,
-    #[serde(rename = "bio")]
     pub bio: Option<String>,
-    #[serde(rename = "image")]
     pub image: Option<String>,
-    #[serde(rename = "createdAt")]
     pub created_at:
         ::prisma_client_rust::chrono::DateTime<::prisma_client_rust::chrono::FixedOffset>,
-    #[serde(rename = "updatedAt")]
     pub updated_at:
         ::prisma_client_rust::chrono::DateTime<::prisma_client_rust::chrono::FixedOffset>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
 
     let prisma_client = Arc::new(PrismaClient::_builder().build().await?);
 
-    let cors = CorsLayer::new().allow_methods(Any).allow_origin(Any);
+    let cors = CorsLayer::new().allow_methods(Any).allow_headers(Any).allow_origin(Any);
 
     let app = AppRouter::new()
         .layer(cors)


### PR DESCRIPTION
Remove redundancy serde rename and Added allow_headers to avoid request error: 
`Cross-Origin` Request Blocked: The Same Origin Policy disallows reading the remote resource at http://127.0.0.1:8000/articles?limit=10&offset=0. (Reason: header ‘content-type’ is not allowed according to header ‘Access-Control-Allow-Headers’ from CORS preflight response).`
<img width="585" alt="image" src="https://github.com/chojs23/realworld-axum-prisma/assets/139340982/3d37efc0-0681-4d67-9ad1-67ec78dcb412">
